### PR TITLE
Update .travis.yml: only build on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# safelist
+branches:
+  only:
+  - master
 before_install:
   - gem install cocoapods
   - pod repo update


### PR DESCRIPTION
This prevents cluttering up the Travis CI branches page with a list of every single branch it has built on (there is currently no way of deleting it).