### PR TITLE
Fix bug: Travis build passing when tests failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_install:
 install:
   - pod install
 script:
-  - xcodebuild clean test -workspace bacon.xcworkspace -scheme bacon -destination "platform=iOS Simulator,name=iPhone 7,OS=12.1" -quiet | xcpretty
+  - set -o pipefail && xcodebuild clean test -workspace bacon.xcworkspace -scheme bacon -destination "platform=iOS Simulator,name=iPhone 7,OS=12.1" -quiet | xcpretty
   - swiftlint


### PR DESCRIPTION
This happened because piping xcodebuild to xcpretty causes errors to be "eaten up". This is documented in xcpretty's documentation (https://github.com/xcpretty/xcpretty).

This commit fixes that by exiting xcpretty with the same status code as xcodebuild.