### PR TITLE
Hashable classes

### DIFF
--- a/bacon.xcodeproj/project.pbxproj
+++ b/bacon.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0B931CE7463280668924F212 /* Pods_baconTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 894FB0A0BC60BFB913FD0FD0 /* Pods_baconTests.framework */; };
+		8F0B2073225A464D001AF3BA /* HashableClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0B2072225A464D001AF3BA /* HashableClass.swift */; };
 		8F3121D9224A39D100A9A554 /* TransactionTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3121D8224A39D100A9A554 /* TransactionTime.swift */; };
 		8F3121DB224A3B9800A9A554 /* TransactionTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3121DA224A3B9800A9A554 /* TransactionTimeTests.swift */; };
 		8F6A7A402240B583002E695A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6A7A3F2240B583002E695A /* AppDelegate.swift */; };
@@ -77,6 +78,7 @@
 		4701C832F23C08627A348028 /* Pods_bacon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_bacon.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6542309D6C94355D2328ACB3 /* Pods-bacon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bacon.debug.xcconfig"; path = "Pods/Target Support Files/Pods-bacon/Pods-bacon.debug.xcconfig"; sourceTree = "<group>"; };
 		894FB0A0BC60BFB913FD0FD0 /* Pods_baconTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_baconTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F0B2072225A464D001AF3BA /* HashableClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashableClass.swift; sourceTree = "<group>"; };
 		8F3121D8224A39D100A9A554 /* TransactionTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTime.swift; sourceTree = "<group>"; };
 		8F3121DA224A3B9800A9A554 /* TransactionTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTimeTests.swift; sourceTree = "<group>"; };
 		8F6A7A3C2240B583002E695A /* bacon.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bacon.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -249,6 +251,7 @@
 				8FD0EC8A22533E3E00FCCBFB /* CodableUIImage.swift */,
 				BE665F962253A455002EBA74 /* String+initFromCLPlacemark.swift */,
 				BEC5743F2254A301001793EC /* Decimal+toFormattedString.swift */,
+				8F0B2072225A464D001AF3BA /* HashableClass.swift */,
 			);
 			path = commons;
 			sourceTree = "<group>";
@@ -579,6 +582,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8FD5F7CB2240E7620023A7FC /* Transaction.swift in Sources */,
+				8F0B2073225A464D001AF3BA /* HashableClass.swift in Sources */,
 				BEF38D0B224BA1C500BC8927 /* FoldingCell.swift in Sources */,
 				8F6A7A422240B583002E695A /* MainPageViewController.swift in Sources */,
 				9F2E21D92240FE9000C5A31E /* StorageCouchBaseDB.swift in Sources */,

--- a/bacon/commons/HashableClass.swift
+++ b/bacon/commons/HashableClass.swift
@@ -1,0 +1,25 @@
+//
+//  HashableClass.swift
+//  bacon
+//
+//  Created by Fabian Terh on 7/4/19.
+//  Copyright © 2019 nus.CS3217. All rights reserved.
+//
+
+import Foundation
+
+/// A Hashable superclass for instant conformance to the Hashable protocol.
+/// - Note: Hash values are derived from the instance's object identifier.
+///     == is overridden to return === instead.
+///     If instance properties comparison is required, consider implementing an `equals()` method instead.
+class HashableClass: Equatable, Hashable {
+
+    static func == (lhs: HashableClass, rhs: HashableClass) -> Bool {
+        return lhs === rhs
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+}

--- a/bacon/model/Transaction.swift
+++ b/bacon/model/Transaction.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: Transaction class
 /// Represents a mutable transaction.
-class Transaction: Codable, Observable {
+class Transaction: HashableClass, Codable, Observable {
 
     // Support transaction deletion through the delete() method.
     // These variables should be externally readable but not settable.
@@ -143,8 +143,8 @@ class Transaction: Codable, Observable {
 
 }
 
-// MARK: Transaction: Equatable
-extension Transaction: Equatable {
+// MARK: Transaction: equals()
+extension Transaction {
 
     /// Compares 2 transactions.
     /// - Returns: true if they have equal properties.
@@ -157,24 +157,6 @@ extension Transaction: Equatable {
             && description == transaction.description
             && location == transaction.location
             && image?.image.pngData()?.base64EncodedString() == transaction.image?.image.pngData()?.base64EncodedString()
-    }
-
-    // We check for identity so we don't end up with a situation where
-    // transaction1 == transaction2 but transaction1 has a different hash value from transaction2.
-    // For comparison of transaction properties, use .equals() instead.
-    static func == (lhs: Transaction, rhs: Transaction) -> Bool {
-        return lhs === rhs
-    }
-
-}
-
-// MARK: Transaction: Hashable
-extension Transaction: Hashable {
-
-    // We use ObjectIdentifier(self) so 2 distinct but equivalent transactions hash to different values.
-    // This lets us map distinct Transaction objects to arbitrary values, even if some may be equivalent.
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(self))
     }
 
 }

--- a/bacon/model/Transaction.swift
+++ b/bacon/model/Transaction.swift
@@ -156,7 +156,8 @@ extension Transaction {
             && amount == transaction.amount
             && description == transaction.description
             && location == transaction.location
-            && image?.image.pngData()?.base64EncodedString() == transaction.image?.image.pngData()?.base64EncodedString()
+            && image?.image.pngData()?.base64EncodedString()
+                == transaction.image?.image.pngData()?.base64EncodedString()
     }
 
 }

--- a/baconTests/model/StorageManagerTests.swift
+++ b/baconTests/model/StorageManagerTests.swift
@@ -270,7 +270,6 @@ class StorageManagerTests: XCTestCase {
             XCTAssertTrue(transaction.equals(loadedFoodTransactions[index]))
         }
 
-
         // Save 3 transactinos of category .transport
         let transportTransactions = [TestUtils.validTransactionTransport03,
                                      TestUtils.validTransactionTransport02,

--- a/baconTests/model/TransactionTests.swift
+++ b/baconTests/model/TransactionTests.swift
@@ -99,8 +99,12 @@ class TransactionTests: XCTestCase {
                                             amount: 1)
 
         XCTAssertTrue(transaction1.equals(transaction2))
-        XCTAssertNotEqual(transaction1, transaction2) // We override == to check for ===
-        XCTAssertNotEqual(transaction1.hashValue, transaction2.hashValue) // Hash values should be derived from object identifiers
+
+        // We override == to check for ===
+        XCTAssertNotEqual(transaction1, transaction2)
+
+        // Hash values should be derived from object identifiers
+        XCTAssertNotEqual(transaction1.hashValue, transaction2.hashValue)
 
         var dict: [Transaction: Int] = [:]
         var set: Set<Transaction> = []


### PR DESCRIPTION
I created a Hashable superclass for reuse. Basically, I refactored the logic for conforming Transaction to Equatable and Hashable into this HashableClass superclass, then updated Transaction to inherit HashableClass.

This way, we can make any other class Hashable in future by just inheriting from HashableClass.

Also fixed some swiftlint violations.