### PR TITLE
Edit transactions

### DIFF
--- a/bacon/model/Transaction.swift
+++ b/bacon/model/Transaction.swift
@@ -100,11 +100,7 @@ class Transaction: HashableClass, Codable, Observable {
          description: String = "",
          image: CodableUIImage? = nil,
          location: CodableCLLocation? = nil) throws {
-        log.info("""
-            Transaction:init() with the following arguments:
-            date=\(date) type=\(type) frequency=\(frequency) category=\(category)
-            amount=\(amount) description=\(description) location=\(String(describing: location))
-            """)
+        log.info("Initializing Transaction object.")
 
         self.date = date
         self.type = type
@@ -126,8 +122,11 @@ class Transaction: HashableClass, Codable, Observable {
                          image: image,
                          location: location)
         } catch let error as InvalidTransactionError {
+            log.warning("Transaction initialization failed (InvalidTransactionError). Re-throwing as InitializationError.")
             throw InitializationError(message: error.message) // Propagate error as InitializationError
         }
+
+        log.info("Transaction initialization succeeded.")
     }
 
     /// Edits one or more properties of a Transaction object.
@@ -144,6 +143,7 @@ class Transaction: HashableClass, Codable, Observable {
               image: CodableUIImage? = nil,
               location: CodableCLLocation? = nil) throws {
         do {
+            log.info("Editing Transaction instance.")
             try validate(date: date,
                          type: type,
                          frequency: frequency,
@@ -153,6 +153,7 @@ class Transaction: HashableClass, Codable, Observable {
                          image: image,
                          location: location)
         } catch let error as InvalidTransactionError {
+            log.warning("Transaction editing failed (InvalidTransactionError. Rethrowing error.")
             throw error
         }
 
@@ -183,12 +184,13 @@ class Transaction: HashableClass, Codable, Observable {
             self.location = location
         }
 
+        log.info("Transaction editing succeeded.")
     }
 
     /// Notifies all observers of changes to self.
     /// This should be called after any mutation to a Transaction instance.
     private func notifyObserversOfSelf() {
-        log.info("Notifying observers of new self")
+        log.info("Notifying observers of new self.")
         notifyObservers(self)
     }
 
@@ -225,6 +227,8 @@ extension Transaction {
                           description: String? = nil,
                           image: CodableUIImage? = nil,
                           location: CodableCLLocation? = nil) throws {
+        log.info("Validating transaction properties.")
+
         /* Currently, we only validate `amount`.
          * This method should be extended as required in the future.
          * For each property to be checked, we first check that it is not nil,
@@ -233,8 +237,11 @@ extension Transaction {
 
         // Validation condition: amount should be > 0
         if (amount != nil && amount! <= 0) {
+            log.warning("Amount=\(String(describing: amount)) is invalid. Throwing InvalidTransactionError.")
             throw InvalidTransactionError(message: "amount=\(amount!) must be > 0")
         }
+
+        log.info("Transaction properties validation succeeded.")
     }
 
 }

--- a/bacon/model/Transaction.swift
+++ b/bacon/model/Transaction.swift
@@ -130,6 +130,61 @@ class Transaction: HashableClass, Codable, Observable {
         }
     }
 
+    /// Edits one or more properties of a Transaction object.
+    /// Pass in as many properties as should be edited.
+    /// - Note: If properties are valid, observers of this Transaction object are notified automatically.
+    ///     Otherwise, this Transaction object will not be mutated, and observers will not be notified.
+    /// - Throws: `InvalidTransactionError` if at least 1 property is invalid.
+    func edit(date: Date? = nil,
+              type: TransactionType? = nil,
+              frequency: TransactionFrequency? = nil,
+              category: TransactionCategory? = nil,
+              amount: Decimal? = nil,
+              description: String? = nil,
+              image: CodableUIImage? = nil,
+              location: CodableCLLocation? = nil) throws {
+        do {
+            try validate(date: date,
+                         type: type,
+                         frequency: frequency,
+                         category: category,
+                         amount: amount,
+                         description: description,
+                         image: image,
+                         location: location)
+        } catch let error as InvalidTransactionError {
+            throw error
+        }
+
+        // Update properties for those which are not nil
+
+        if let date = date {
+            self.date = date
+        }
+        if let type = type {
+            self.type = type
+        }
+        if let frequency = frequency {
+            self.frequency = frequency
+        }
+        if let category = category {
+            self.category = category
+        }
+        if let amount = amount {
+            self.amount = amount
+        }
+        if let description = description {
+            self.description = description
+        }
+        if let image = image {
+            self.image = image
+        }
+        if let location = location {
+            self.location = location
+        }
+
+    }
+
     /// Notifies all observers of changes to self.
     /// This should be called after any mutation to a Transaction instance.
     private func notifyObserversOfSelf() {

--- a/bacon/model/Transaction.swift
+++ b/bacon/model/Transaction.swift
@@ -18,49 +18,49 @@ class Transaction: HashableClass, Codable, Observable {
     private(set) var deleteSuccessCallback: () -> Void = {}
     private(set) var deleteFailureCallback: (String) -> Void = { _ in }
 
-    var date: Date {
+    private(set) var date: Date {
         didSet {
             log.info("Set date=\(date)")
             notifyObserversOfSelf()
         }
     }
-    var type: TransactionType {
+    private(set) var type: TransactionType {
         didSet {
             log.info("Set type=\(type)")
             notifyObserversOfSelf()
         }
     }
-    var frequency: TransactionFrequency {
+    private(set) var frequency: TransactionFrequency {
         didSet {
             log.info("Set frequency=\(frequency)")
             notifyObserversOfSelf()
         }
     }
-    var category: TransactionCategory {
+    private(set) var category: TransactionCategory {
         didSet {
             log.info("Set category=\(category)")
             notifyObserversOfSelf()
         }
     }
-    var amount: Decimal {
+    private(set) var amount: Decimal {
         didSet {
             log.info("Set amount=\(amount)")
             notifyObserversOfSelf()
         }
     }
-    var description: String {
+    private(set) var description: String {
         didSet {
             log.info("Set description=\(description)")
             notifyObserversOfSelf()
         }
     }
-    var image: CodableUIImage? {
+    private(set) var image: CodableUIImage? {
         didSet {
             log.info("Updated image")
             notifyObserversOfSelf()
         }
     }
-    var location: CodableCLLocation? {
+    private(set) var location: CodableCLLocation? {
         didSet {
             log.info("Set location=\(String(describing: location))")
             notifyObserversOfSelf()

--- a/baconTests/TestUtils.swift
+++ b/baconTests/TestUtils.swift
@@ -64,6 +64,27 @@ class TestUtils {
     //       transaction properties should differ from each other.
     // --------------------------------------------------
 
+    // An array containing ALL valid transactions defined in TestUtils.
+    // Remember to update this if you are creating new valid transactions.
+    static let validTransactions = [validTransactionExpenditure01,
+                                       validTransactionExpenditure02,
+                                       validTransactionExpenditure03,
+                                       validTransactionExpenditure04,
+                                       validTransactionIncome01,
+                                       validTransactionIncome02,
+                                       validTransactionIncome03,
+                                       validTransactionFood01,
+                                       validTransactionFood02,
+                                       validTransactionFood03,
+                                       validTransactionTransport01,
+                                       validTransactionTransport02,
+                                       validTransactionTransport03,
+                                       validTransactionDate01,
+                                       validTransactionDate01point2,
+                                       validTransactionDate02,
+                                       validTransactionDate02point2,
+                                       validTransactionDate03]
+
     // TRANSACTION - TYPE - EXPENDITURE
     static let validTransactionExpenditure01 =
         try! Transaction(date: Date(timeIntervalSince1970: TimeInterval(0)),
@@ -170,6 +191,15 @@ class TestUtils {
                          amount: 25.0)
 
     // TRANSACTION - TIME
+
+    // An array containing ALL test dates defined in TestUtils.
+    // Remember to update this if you are creating a new valid date object.
+    static let testDates = [january1st2019time0800,
+                            january1st2019time1000,
+                            january2nd2019time1320,
+                            january2nd2019time1500,
+                            january5th2019time1230]
+
     static let january1st2019time0800 = Constants.getDateFormatter().date(from: "2019-01-01 08:00:00")!
     static let january1st2019time1000 = Constants.getDateFormatter().date(from: "2019-01-01 10:00:00")!
     static let january2nd2019time1320 = Constants.getDateFormatter().date(from: "2019-01-02 13:20:00")!

--- a/baconTests/model/TransactionTests.swift
+++ b/baconTests/model/TransactionTests.swift
@@ -12,16 +12,15 @@ import XCTest
 @testable import bacon
 
 class TransactionTests: XCTestCase {
-    let testDate = Date()
     let testFrequency = try! TransactionFrequency(nature: .oneTime)
 
     func test_init_validInput_success() {
-        let transaction = try! Transaction(date: testDate,
+        let transaction = try! Transaction(date: TestUtils.january1st2019time0800,
                                            type: .expenditure,
                                            frequency: testFrequency,
                                            category: .bills,
                                            amount: 1)
-        XCTAssertEqual(transaction.date, testDate)
+        XCTAssertEqual(transaction.date, TestUtils.january1st2019time0800)
         XCTAssertEqual(transaction.type, .expenditure)
         XCTAssertEqual(transaction.frequency, testFrequency)
         XCTAssertEqual(transaction.category, .bills)
@@ -30,7 +29,7 @@ class TransactionTests: XCTestCase {
     }
 
     func test_init_invalidNegativeAmount() {
-        XCTAssertThrowsError(try Transaction(date: testDate,
+        XCTAssertThrowsError(try Transaction(date: TestUtils.january1st2019time0800,
                                              type: .expenditure,
                                              frequency: testFrequency,
                                              category: .bills,
@@ -40,7 +39,7 @@ class TransactionTests: XCTestCase {
     }
 
     func test_init_invalidZeroAmount() {
-        XCTAssertThrowsError(try Transaction(date: testDate,
+        XCTAssertThrowsError(try Transaction(date: TestUtils.january1st2019time0800,
                                              type: .expenditure,
                                              frequency: testFrequency,
                                              category: .bills,
@@ -50,37 +49,39 @@ class TransactionTests: XCTestCase {
     }
 
     func test_editTransaction_validProperties() {
-        let transaction = try! Transaction(date: testDate,
-                                           type: .expenditure,
-                                           frequency: testFrequency,
-                                           category: .bills,
-                                           amount: 1)
-        XCTAssertNoThrow(try transaction.edit(type: .income))
+        // Stress test with all valid transactions
+        // Test with editing multiple properties (3 and 2), and single property
+        try! TestUtils.validTransactions.forEach { transaction in
+            XCTAssertNoThrow(try transaction.edit(date: TestUtils.january1st2019time0800,
+                                                  type: .expenditure,
+                                                  frequency: testFrequency))
+            XCTAssertNoThrow(try transaction.edit(category: .transport,
+                                                  amount: 100))
+            XCTAssertNoThrow(try transaction.edit(description: "foo"))
+        }
     }
 
     func test_editTransaction_invalidProperties() {
-        let transaction = try! Transaction(date: testDate,
-                                           type: .expenditure,
-                                           frequency: testFrequency,
-                                           category: .bills,
-                                           amount: 1)
-        XCTAssertThrowsError(try transaction.edit(amount: -1)) { err in
-            XCTAssertTrue(type(of: err) == InvalidTransactionError.self)
+        // Stress test with all valid transactions
+        try! TestUtils.validTransactions.forEach { transaction in
+            XCTAssertThrowsError(try transaction.edit(amount: -1)) { err in
+                XCTAssertTrue(err is InvalidTransactionError)
+            }
         }
     }
 
     func test_transaction_equal() {
-        let transaction = try! Transaction(date: testDate,
+        let transaction = try! Transaction(date: TestUtils.january1st2019time1000,
                                            type: .expenditure,
                                            frequency: testFrequency,
                                            category: .bills,
                                            amount: 1)
-        let transaction2 = try! Transaction(date: testDate,
+        let transaction2 = try! Transaction(date: TestUtils.january1st2019time1000,
                                             type: .expenditure,
                                             frequency: testFrequency,
                                             category: .bills,
                                             amount: 1)
-        let transaction3 = try! Transaction(date: testDate,
+        let transaction3 = try! Transaction(date: TestUtils.january1st2019time1000,
                                             type: .income,
                                             frequency: testFrequency,
                                             category: .food,
@@ -90,7 +91,7 @@ class TransactionTests: XCTestCase {
     }
 
     func test_transactionObservable() {
-        let transaction = try! Transaction(date: testDate,
+        let transaction = try! Transaction(date: TestUtils.january1st2019time1000,
                                            type: .expenditure,
                                            frequency: testFrequency,
                                            category: .bills,
@@ -107,12 +108,12 @@ class TransactionTests: XCTestCase {
     }
 
     func test_transactionHashable() {
-        let transaction1 = try! Transaction(date: testDate,
+        let transaction1 = try! Transaction(date: TestUtils.january2nd2019time1500,
                                             type: .expenditure,
                                             frequency: testFrequency,
                                             category: .bills,
                                             amount: 1)
-        let transaction2 = try! Transaction(date: testDate,
+        let transaction2 = try! Transaction(date: TestUtils.january2nd2019time1500,
                                             type: .expenditure,
                                             frequency: testFrequency,
                                             category: .bills,

--- a/baconTests/model/TransactionTests.swift
+++ b/baconTests/model/TransactionTests.swift
@@ -80,9 +80,9 @@ class TransactionTests: XCTestCase {
         transaction.registerObserver(observer)
 
         XCTAssertEqual(observer.notifiedCount, 0)
-        transaction.amount = 2 // Set amount to new value
+        try! transaction.edit(amount: 2) // Set amount to new value
         XCTAssertEqual(observer.notifiedCount, 1)
-        transaction.amount = 2 // Set amount to same value
+        try! transaction.edit(amount: 2) // Set amount to same value
         XCTAssertEqual(observer.notifiedCount, 2)
     }
 

--- a/baconTests/model/TransactionTests.swift
+++ b/baconTests/model/TransactionTests.swift
@@ -49,6 +49,26 @@ class TransactionTests: XCTestCase {
         }
     }
 
+    func test_editTransaction_validProperties() {
+        let transaction = try! Transaction(date: testDate,
+                                           type: .expenditure,
+                                           frequency: testFrequency,
+                                           category: .bills,
+                                           amount: 1)
+        XCTAssertNoThrow(try transaction.edit(type: .income))
+    }
+
+    func test_editTransaction_invalidProperties() {
+        let transaction = try! Transaction(date: testDate,
+                                           type: .expenditure,
+                                           frequency: testFrequency,
+                                           category: .bills,
+                                           amount: 1)
+        XCTAssertThrowsError(try transaction.edit(amount: -1)) { err in
+            XCTAssertTrue(type(of: err) == InvalidTransactionError.self)
+        }
+    }
+
     func test_transaction_equal() {
         let transaction = try! Transaction(date: testDate,
                                            type: .expenditure,


### PR DESCRIPTION
* Use edit() method instead of directly mutate, so we can validate transaction properties (i.e. checkRep)
* Refactor validation logic in init to validate() method