### PR TITLE
Integrate tag removal method to CoreLogic

### DIFF
--- a/bacon/controller/CoreLogic.swift
+++ b/bacon/controller/CoreLogic.swift
@@ -115,4 +115,18 @@ class CoreLogic: CoreLogicInterface {
     func addChildTag(_ child: String, to parent: String) throws -> Tag {
         return try tagManager.addChildTag(child, to: parent)
     }
+
+    func removeChildTag(_ child: String, from parent: String) throws {
+        let removedTags = try tagManager.removeChildTag(child, from: parent)
+        for tags in removedTags {
+            try transactionManager.deleteTagFromTransactions(tags)
+        }
+    }
+
+    func removeParentTag(_ parent: String) throws {
+        let removedTags = try tagManager.removeParentTag(parent)
+        for tags in removedTags {
+            try transactionManager.deleteTagFromTransactions(tags)
+        }
+    }
 }

--- a/bacon/controller/CoreLogic.swift
+++ b/bacon/controller/CoreLogic.swift
@@ -129,6 +129,7 @@ class CoreLogic: CoreLogicInterface {
         for tags in removedTags {
             try transactionManager.deleteTagFromTransactions(tags)
         }
+    }
 
     // MARK: Prediction related
     func getPrediction(_ time: Date, _ location: CodableCLLocation,

--- a/bacon/controller/CoreLogicInterface.swift
+++ b/bacon/controller/CoreLogicInterface.swift
@@ -25,4 +25,13 @@ protocol CoreLogicInterface {
     // MARK: Budget Related
     func saveBudget(_ budget: Budget) throws
     func loadBudget() throws -> Budget
+    func getSpendingStatus() throws -> SpendingStatus
+
+    // Mark: Tag Related
+    func getAllTags() -> [Tag: [Tag]]
+    func getAllParentTags() -> [Tag]
+    func addParentTag(_ name: String) throws -> Tag
+    func addChildTag(_ child: String, to parent: String) throws -> Tag
+    func removeChildTag(_ child: String, from parent: String) throws
+    func removeParentTag(_ parent: String) throws
 }

--- a/bacon/controller/TransactionManager.swift
+++ b/bacon/controller/TransactionManager.swift
@@ -20,7 +20,7 @@ class TransactionManager: Observer {
     }
 
     // Observer is responsible for knowing what object types it observes
-    // TransactionManager observes Transactions and TagManager
+    // TransactionManager currently only observes Transactions
     func notify(_ value: Any) {
         // Notified by Transaction
         if let transaction = value as? Transaction {
@@ -47,21 +47,6 @@ class TransactionManager: Observer {
             """)
             return
         }
-        // Notified by TagManager
-        if let tag = value as? Tag {
-            // TODO
-            // Update notify to have callback
-            // Handle the error below
-            do {
-                try storageManager.deleteTagFromTransactions(tag)
-            } catch {
-                //zuo bo for now
-            }
-            log.info("""
-                TransactionManager notified by TagManager to delete tag: \(tag)
-            """)
-            return
-        }
         // If program enters here
         // meaning, an error has occured, TransactionManager is notified by
         // objects it doesn't observe.
@@ -85,6 +70,10 @@ class TransactionManager: Observer {
 
     func saveTransaction(_ transaction: Transaction) throws {
         try storageManager.saveTransaction(transaction)
+    }
+
+    func deleteTagFromTransactions(_ tag: Tag) throws {
+        try storageManager.deleteTagFromTransactions(tag)
     }
 
     func loadTransactions(limit: Int) throws -> [Transaction] {

--- a/bacon/model/Tags/TagManager.swift
+++ b/bacon/model/Tags/TagManager.swift
@@ -578,11 +578,11 @@ extension TagManager {
             }
 
             // Remove all children Tags
+            removedTags.append(contentsOf: try getChildrenTags(of: displayValue))
             guard let childrenTagValues = parentChildMap[displayValue] else {
                 fatalError("This should never happen")
             }
             for childTagValue in childrenTagValues {
-                removedTags.append(contentsOf: try getChildrenTags(of: displayValue))
                 try removeTag(childTagValue, of: displayValue)
             }
 

--- a/bacon/model/Tags/TagManager.swift
+++ b/bacon/model/Tags/TagManager.swift
@@ -322,7 +322,7 @@ class TagManager: Codable, Observable, TagManagerInterface {
 
     }
 
-    func removeChildTag(_ child: String, from parent: String) throws {
+    func removeChildTag(_ child: String, from parent: String) throws -> [Tag] {
         // Parent Tag should exist
         guard let children = parentChildMap[parent] else {
             throw InvalidTagError(message: "Parent tag \(parent) does not exist")
@@ -333,17 +333,16 @@ class TagManager: Codable, Observable, TagManagerInterface {
             throw InvalidTagError(message: "Child tag \(child) does not exist")
         }
 
-        removeTag(child, of: parent)
-
+        return try removeTag(child, of: parent)
     }
 
-    func removeParentTag(_ parent: String) throws {
+    func removeParentTag(_ parent: String) throws -> [Tag] {
         // Parent Tag should exist
         guard parentChildMap[parent] != nil else {
             throw InvalidTagError(message: "Parent tag \(parent) does not exist")
         }
 
-        removeTag(parent)
+        return try removeTag(parent)
     }
 
     var tags: [Tag: [Tag]] {
@@ -564,13 +563,13 @@ extension TagManager {
     /// Removes a Tag. This method automatically updates data stores and saves to disk.
     /// If a parent Tag is removed, all of its children Tags will be removed too.
     /// - Requires: The Tag being removed must exist.
-    private func removeTag(_ displayValue: String, of parentDisplayValue: String? = nil) {
+    @discardableResult
+    private func removeTag(_ displayValue: String,
+                           of parentDisplayValue: String? = nil) throws -> [Tag] {
         let removedTag: Tag
-        do {
-            removedTag = try getTag(for: displayValue, of: parentDisplayValue)
-        } catch {
-            fatalError("This should never happen") // Tag has not been remoed
-        }
+        var removedTags: [Tag] = []
+        removedTag = try getTag(for: displayValue, of: parentDisplayValue)
+        removedTags.append(removedTag)
 
         let isParentTag = parentDisplayValue == nil
         if isParentTag {
@@ -583,7 +582,8 @@ extension TagManager {
                 fatalError("This should never happen")
             }
             for childTagValue in childrenTagValues {
-                removeTag(childTagValue, of: displayValue)
+                removedTags.append(contentsOf: try getChildrenTags(of: displayValue))
+                try removeTag(childTagValue, of: displayValue)
             }
 
             parentValueIdMap[displayValue] = nil
@@ -607,7 +607,7 @@ extension TagManager {
         }
 
         save()
-        notifyObservers(removedTag)
+        return removedTags
     }
 
 }

--- a/bacon/model/Tags/TagManagerInterface.swift
+++ b/bacon/model/Tags/TagManagerInterface.swift
@@ -34,11 +34,11 @@ protocol TagManagerInterface {
 
     /// Removes a child Tag from a parent Tag.
     /// - Throws: `InvalidTagError` if either Tag does not exist.
-    func removeChildTag(_ child: String, from parent: String) throws
+    func removeChildTag(_ child: String, from parent: String) throws -> [Tag]
 
     /// Removes a parent Tag. All of its children Tags will be removed too.
     /// - Throws: `InvalidTagError` if the Tag does not exist.
-    func removeParentTag(_ parent: String) throws
+    func removeParentTag(_ parent: String) throws -> [Tag]
 
     /// Contains all Tags in a dictionary mapping parent Tags to sorted arrays of their children Tags.
     var tags: [Tag: [Tag]] { get }


### PR DESCRIPTION
Added methods to CoreLogicInterface
Remove observer code for TagManager in TransactionManager
Added deleteTagFromTransactions() to TransactionManager
Modified removeChildTag() and removeParentTag() to return removed tags in an array
Modified removeTag() to throw
